### PR TITLE
Add PICO spatial data permission to constants.kt

### DIFF
--- a/plugin/src/main/java/org/godotengine/openxr/vendors/Constants.kt
+++ b/plugin/src/main/java/org/godotengine/openxr/vendors/Constants.kt
@@ -57,10 +57,12 @@ internal val META_PERMISSIONS_LIST = listOf(
 // Pico permissions
 internal const val PICO_EYE_TRACKING_PERMISSION = "com.picovr.permission.EYE_TRACKING"
 internal const val PICO_FACE_TRACKING_PERMISSION = "com.picovr.permission.FACE_TRACKING"
+internal const val PICO_SPATIAL_DATA_PERMISSION = "com.picovr.permission.SPATIAL_DATA"
 
 internal val PICO_PERMISSIONS_LIST = listOf(
     PICO_EYE_TRACKING_PERMISSION,
     PICO_FACE_TRACKING_PERMISSION,
+    PICO_SPATIAL_DATA_PERMISSION,
 )
 
 internal fun getVendorPermissions(vendorName: String): List<String> {


### PR DESCRIPTION
@m4gr3d looks like this does the trick to also ask for the permission.

Nice thing at least for spatial anchors seems to be that we can create the spatial context even without the permission, it just won't return data until permission is given. 